### PR TITLE
Allow for lower-case field names bdsk-file-1

### DIFF
--- a/bibdesk2zotero.py
+++ b/bibdesk2zotero.py
@@ -45,7 +45,7 @@ def convert(bib_file, base_dir):
     for key in db.entries:
         entry = db.entries[key]
         for field_name in entry.fields:
-            m = re.match('^Bdsk-File-(\d+)$', field_name)
+            m = re.match('^[Bb]dsk-[Ff]ile-(\d+)$', field_name)
             if m:
                 bdsk = entry.fields[field_name]
                 bdsk_decoded = base64.b64decode(bdsk)


### PR DESCRIPTION
In my bibdesk file, the file fields are called "bdsk-file-1" etc., not "Bdsk-File-1". I've adjusted the regex to also recognize the fields in that case.