### PR TITLE
Fix ModuleNotFoundError due to missing pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,6 @@ setup(
     description = 'convert BibDesk BibTeX files for import into Zotero',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    install_requires = ['pybtex'],
+    install_requires = ['pybtex', 'setuptools>=40.4.3'],
     entry_points = {'console_scripts': ['bibdesk2zotero = bibdesk2zotero:main']},
 )


### PR DESCRIPTION
The `ModuleNotFoundError: pkg_resources` occurs when the underlying virtualenv does not have `setuptools` installed, e.g. when installed with `uv tool install bibdesk2zotero`. This is because `pybtex<=0.24` import `pkg_resources` module, which is contained in the `setuptools` package. Note that for `pybtex>0.24` (not released yet), they drop dependency on it and use instead `importlib`, part of the python stdlib. This means `setuptools` will not be needed for `pybtex>0.24`.

I did a bisect search and found that setuptools>=40.4.3 is required for the bibdesk2zotero script to work.